### PR TITLE
启用缓存和fair模块

### DIFF
--- a/配置文件（非Windows用户使用）/nginx.conf
+++ b/配置文件（非Windows用户使用）/nginx.conf
@@ -25,7 +25,7 @@ http {
     #access_log  logs/access.log  main;
 
     sendfile        on;
-    #tcp_nopush     on;
+    tcp_nopush     on;
 
     #keepalive_timeout  0;
     keepalive_timeout  65;
@@ -34,27 +34,55 @@ http {
     server_names_hash_bucket_size 1024;
 
     #gzip  on;
-    
+
+    proxy_buffer_size 16k;
+    proxy_buffers 4 32k;
+    proxy_busy_buffers_size 96k;
+    proxy_temp_file_write_size 96k;
+    proxy_temp_path /tmp/temp_dir;
+    proxy_cache_path /tmp/cache keys_zone=cache_one:16m max_size=1g;
+
     upstream www-pixiv-net { 
+        #fair;
         server 210.140.131.182:443;
         server 210.140.131.180:443;
         server 210.140.131.184:443;
+        server 210.140.131.218:443;
+        server 210.140.131.224:443;
+        server 210.140.131.222:443;
     }
     
     upstream sketch-pixiv-net { 
+        #fair;
         server 210.140.174.37:443;
         server 210.140.170.179:443;
         server 210.140.175.130:443;
     }
     
     upstream imgaz-pixiv-net { 
+        #fair;
         server 210.140.131.145:443;
         server 210.140.131.144:443;
         server 210.140.131.147:443;
         server 210.140.131.153:443;
     }
-    
-    upstream i-pximg-net { 
+
+    upstream dic-pixiv-net {
+        #fair;
+        server 210.140.131.145:443;
+        server 210.140.131.144:443;
+        server 210.140.131.147:443;
+        server 210.140.131.153:443;
+    }
+   
+   upstream d-pixiv-org {
+           #fair;
+           server 210.140.131.159:443;
+           server 210.140.131.158:443;
+           server 210.140.131.157:443;
+   }
+   upstream i-pximg-net { 
+        #fair;
         server 210.140.92.140:443;
         server 210.140.92.137:443;
         server 210.140.92.139:443;
@@ -64,6 +92,29 @@ http {
         server 210.140.92.143:443;
         server 210.140.92.135:443;
         server 210.140.92.136:443; 
+        server 210.140.92.138:443;
+    }
+
+    upstream wikipedia-org {
+        #fair;
+        server 208.80.154.224:443;
+        server 103.102.166.224:443;
+        server 91.198.174.192:443;
+        server 198.35.26.96:443;
+    }
+
+    upstream steamcommunity-com {
+        #fair;
+        server 104.76.172.254:443;
+        server 104.115.120.214:443;
+        server 104.76.68.208:443;
+        server 104.107.11.147:443;
+        server 104.84.184.44:443;
+        server 104.82.193.193:443;
+        server 184.31.39.249:443;
+        server 104.85.197.14:443;
+        server 23.42.175.221:443;
+        server 23.62.130.245:443;
     }
     
     server {
@@ -80,58 +131,134 @@ http {
         server_name touch.pixiv.net;
         server_name oauth.secure.pixiv.net;
 
-        ssl on;
+	#ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-        
-        client_max_body_size 50M;
-        
-    	location / {
+
+        client_max_body_size 64M;
+
+        location / {
             proxy_pass https://www-pixiv-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
         }
-	}
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://www-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://www-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
     
     server {
         listen 443 ssl;
         server_name i.pximg.net;
+        server_name s.pximg.net;
 
-        ssl on;
+	#ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-        
-    	location / {
+		
+        location / {
             proxy_pass https://i-pximg-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
         }
-	}
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://i-pximg-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://i-pximg-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
     
     server {
         listen 443 ssl;
         server_name sketch.pixiv.net;
 
-        ssl on;
+	#ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-
-    	location / {
+		
+        location / {
             proxy_pass https://sketch-pixiv-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
+        }
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://sketch-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://sketch-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
         }
         
         # Proxying WebSockets
@@ -142,26 +269,50 @@ http {
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
         }
-	}
+    }
     
     server {
         listen 443 ssl;
         server_name factory.pixiv.net;
-
-        ssl on;
+        #ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-
-    	location / {
-            proxy_pass https://210.140.131.180/;
+		
+        location / {
+            proxy_pass https://210.140.131.180;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
         }
-	}
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://210.140.131.180;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://210.140.131.180;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
     
     server {
         listen 443 ssl;
@@ -170,21 +321,46 @@ http {
         server_name sensei.pixiv.net;
         server_name fanbox.pixiv.net;
         server_name payment.pixiv.net.pixiv.net;
-
-        ssl on;
+        
+	#ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-        
-    	location / {
-            proxy_pass https://210.140.131.222/;
+	
+        location / {
+            proxy_pass https://dic-pixiv-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
         }
-	}
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://dic-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://dic-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
     
     server {
         listen 443 ssl;
@@ -197,57 +373,177 @@ http {
         server_name i3.pixiv.net;
         server_name i4.pixiv.net;
 
-        ssl on;
+	#ssl on;
         ssl_certificate ca/pixiv.net.crt;
         ssl_certificate_key ca/pixiv.net.key;
-        
-    	location / {
+		
+        location / {
             proxy_pass https://imgaz-pixiv-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
         }
-	}
 
-    upstream wikipedia-server { 
-        server 198.35.26.96:443;
-        server 103.102.166.224:443;
-    }
-    
-    server {
-        listen 443 ssl;
-        server_name *.wikipedia.org;
-        server_name *.m.wikipedia.org;
-
-        ssl on;
-        ssl_certificate ca/pixiv.net.crt;
-        ssl_certificate_key ca/pixiv.net.key;
-        
-    	location / {
-            proxy_pass https://wikipedia-server/;
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://imgaz-pixiv-net;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;
             proxy_set_header User-Agent $http_user_agent;
             proxy_set_header Accept-Encoding ''; 
-            proxy_buffering off;
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
         }
-	}
-    
-    server {
-        listen 443 ssl;
-        server_name  www.google.com;
-        
-        ssl on;
-        ssl_certificate ca/pixiv.net.crt;
-        ssl_certificate_key ca/pixiv.net.key;
 
-        location / {
-            rewrite ^/(.*)$ https://www.recaptcha.net/$1 redirect;
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://imgaz-pixiv-net;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
         }
     }
     
+    server {
+        listen 443 ssl;
+        server_name d.pixiv.org;
+
+	#ssl on;
+        ssl_certificate ca/pixiv.net.crt;
+        ssl_certificate_key ca/pixiv.net.key;
+	
+        location / {
+            proxy_pass https://d-pixiv-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding '';
+        }
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://d-pixiv-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://d-pixiv-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name *.wikipedia.org;
+        server_name *.m.wikipedia.org;
+		
+        #ssl on;
+        ssl_certificate ca/pixiv.net.crt;
+        ssl_certificate_key ca/pixiv.net.key;
+		
+        location / {
+            proxy_pass https://wikipedia-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+        }
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://wikipedia-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://wikipedia-org;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name steamcommunity.com;
+        server_name *.steamcommunity.com;
+
+	#ssl on;
+        ssl_certificate ca/pixiv.net.crt;
+        ssl_certificate_key ca/pixiv.net.key;
+		
+        location / {
+            proxy_pass https://steamcommunity-com;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+        }
+
+        location ~ .*\.(gif|jpg|png|css|js)(.*) {
+            proxy_pass https://steamcommunity-com;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one; 
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;           
+            proxy_cache_valid  200 304 302 60d;
+            expires 60d;
+        }
+
+        location ~ .*\.(eot|ttf|otf|woff|svg)(.*) {
+            proxy_pass https://steamcommunity-com;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header Accept-Encoding ''; 
+            proxy_cache cache_one;
+            proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
+            proxy_cache_valid  200 304 302 90d;
+            expires 90d;
+        }
+    }
 }


### PR DESCRIPTION
#17 
fair模块是一个[第三方模块](https://github.com/itoffshore/nginx-upstream-fair),使用需要重新编译nginx，所以注释掉了```fair;```  
对于缓存的一些参数设置我不太确定，希望作者能修改一下  
新版本好像不推荐使用```ssl on;```,所以注释掉了  
我不是很了解nginx，所以出现问题请原谅