### PR TITLE
upstream  www-pixiv-net  IP update

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -274,7 +274,7 @@ http {
         ssl_certificate_key ca/pixiv.net.key;
         
     	location / {
-            proxy_pass https://104.111.160.41/;
+            proxy_pass https://104.110.72.183/;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real_IP $remote_addr;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -36,9 +36,9 @@ http {
     #gzip  on;
     
     upstream www-pixiv-net { 
-        server 210.140.131.219:443;
-        server 210.140.131.222:443;
-        server 210.140.131.216:443;
+        server 210.140.131.223:443;
+        server 210.140.131.225:443;
+        server 210.140.131.220:443;
     }
     
     upstream sketch-pixiv-net { 


### PR DESCRIPTION
1.更新 www.pixiv.net 及 steamcommunity 的ip地址
2.根据 #33 在更新证书前删除google部分的反代