### PR TITLE
注释清理 现已无法访问的维基百科上游IP

### DIFF
--- a/conf/pixiv.conf
+++ b/conf/pixiv.conf
@@ -275,11 +275,10 @@ server {
 }
 
 upstream wikipedia-text-lb { 
-    #server 198.35.26.96:443;
 	server 208.80.153.224:443;
-	server 208.80.154.224:443;
+	#server 208.80.154.224:443;
 	server 91.198.174.192:443;
-	server 103.102.166.224:443;
+	#server 103.102.166.224:443;
 }
 
 server {


### PR DESCRIPTION
最新情况：（[来源](https://zh.wikipedia.org/wiki/Help:%E5%A6%82%E4%BD%95%E8%AE%BF%E9%97%AE%E7%BB%B4%E5%9F%BA%E7%99%BE%E7%A7%91#%E7%BB%B4%E5%9F%BA%E5%AA%92%E4%BD%93%E6%9C%8D%E5%8A%A1%E5%99%A8%E5%88%97%E8%A1%A8)）
![wikipedia](https://user-images.githubusercontent.com/72609717/101724386-69197880-3ae9-11eb-8fe8-9acccdf9d1aa.png)

error.log :
`2020/12/10 12:30:21 [error] 10132#6404: *1 upstream timed out (10060: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond) while SSL handshaking to upstream, client: 127.0.0.1, server: *.wikipedia.org, request: "GET /wiki/Wikipedia:%E9%A6%96%E9%A1%B5 HTTP/1.1", upstream: "https://103.102.166.224:443/wiki/Wikipedia:%E9%A6%96%E9%A1%B5", host: "zh.wikipedia.org", referrer: "https://zh.wikipedia.org/wiki/Wikipedia:%E9%A6%96%E9%A1%B5"`