### PR TITLE
将显式IP上游更换为无污染dns解析

### DIFF
--- a/conf/pixiv.conf
+++ b/conf/pixiv.conf
@@ -1,52 +1,7 @@
-upstream www-pixiv-net {
-    #server 104.18.12.135:443;
-    #server 104.18.13.135:443;
-    server 210.140.131.223:443;
-    server 210.140.131.225:443;
+upstream pixiv {
+    server 210.140.131.200:443;
+    server 210.140.131.202:443;
     server 210.140.131.220:443;
-}
-
-upstream account-pixiv-net {
-    server 210.140.131.226:443;
-    server 210.140.131.218:443;
-    server 210.140.131.222:443;
-}
-
-upstream sketch-pixiv-net {
-    server 210.140.174.37:443;
-    server 210.140.170.179:443;
-    server 210.140.175.130:443;
-}
-
-upstream sketch-hls-server {
-    server 210.140.214.211:443;
-    server 210.140.214.212:443;
-    server 210.140.214.213:443;
-}
-
-upstream imgaz-pixiv-net {
-    server 210.140.131.145:443;
-    server 210.140.131.144:443;
-    server 210.140.131.147:443;
-    server 210.140.131.153:443;
-}
-
-upstream i-pximg-net {
-    server 210.140.92.140:443;
-    server 210.140.92.137:443;
-    server 210.140.92.139:443;
-    server 210.140.92.142:443;
-    server 210.140.92.134:443;
-    server 210.140.92.141:443;
-    server 210.140.92.143:443;
-    server 210.140.92.136:443;
-    server 210.140.92.138:443;
-    server 210.140.92.144:443;
-    server 210.140.92.145:443;
-}
-
-upstream app-api-pixiv-net {
-    server 210.140.131.218:443;
     server 210.140.131.223:443;
     server 210.140.131.226:443;
 }
@@ -58,8 +13,7 @@ server {
 
 server {
     listen 443 ssl;
-    server_name www.pixiv.net;
-
+    server_name forums.e-hentai.org;
 
     ssl_certificate ca/pixiv.net.crt;
     ssl_certificate_key ca/pixiv.net.key;
@@ -67,8 +21,7 @@ server {
     client_max_body_size 50M;
 
     location / {
-        #proxy_ssl_server_name on;
-        proxy_pass https://www-pixiv-net;
+        proxy_pass https://94.100.18.243:443;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real_IP $remote_addr;
@@ -85,6 +38,8 @@ server {
     server_name accounts.pixiv.net;
     server_name touch.pixiv.net;
     server_name oauth.secure.pixiv.net;
+    server_name www.pixiv.net;
+    server_name app-api.pixiv.net;
 
 
     ssl_certificate ca/pixiv.net.crt;
@@ -93,7 +48,8 @@ server {
     client_max_body_size 50M;
 
     location / {
-        proxy_pass https://account-pixiv-net;
+        # cloudflare代理需要SNI，IP需要指定为非cloudflare
+        proxy_pass https://pixiv;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real_IP $remote_addr;
@@ -105,35 +61,15 @@ server {
 
 server {
     listen 443 ssl;
-    server_name i.pximg.net;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        rewrite ^/(.*)$ https://i.pixiv.cat/$1 redirect;
-
-        # proxy_pass https://i-pximg-net;
-        # proxy_set_header Host $http_host;
-        # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # proxy_set_header X-Real_IP $remote_addr;
-        # proxy_set_header User-Agent $http_user_agent;
-        # proxy_set_header Accept-Encoding '';
-        # proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
     server_name sketch.pixiv.net;
 
-
-    ssl_certificate ca/pixiv.net.crt;
+    resolver 101.6.6.6:5353 valid=300s ipv6=on;
+    
+    ssl_certificate ca/pixiv.net.pem;
     ssl_certificate_key ca/pixiv.net.key;
 
     location / {
-        proxy_pass https://sketch-pixiv-net;
+        proxy_pass https://$http_host;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real_IP $remote_addr;
@@ -144,7 +80,7 @@ server {
 
     # Proxying WebSockets
     location /ws/ {
-        proxy_pass https://sketch-pixiv-net;
+        proxy_pass https://$http_host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -152,110 +88,6 @@ server {
     }
 }
 
-server {
-    listen 443 ssl;
-    server_name *.pixivsketch.net;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://sketch-hls-server;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name factory.pixiv.net;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://210.140.131.180/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name dic.pixiv.net;
-    server_name en-dic.pixiv.net;
-    server_name sensei.pixiv.net;
-    server_name fanbox.pixiv.net;
-    server_name payment.pixiv.net.pixiv.net;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://210.140.131.222/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name imgaz.pixiv.net;
-    server_name comic.pixiv.net;
-    server_name novel.pixiv.net;
-    server_name source.pixiv.net;
-    server_name i1.pixiv.net;
-    server_name i2.pixiv.net;
-    server_name i3.pixiv.net;
-    server_name i4.pixiv.net;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://imgaz-pixiv-net;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name app-api.pixiv.net;
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://app-api-pixiv-net;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
 
 server {
     listen 443 ssl;
@@ -276,215 +108,31 @@ server {
     }
 }
 
-upstream wikipedia-text-lb {
-    server 208.80.153.224:443;
-    #server 208.80.154.224:443;
-    server 91.198.174.192:443;
-    #server 103.102.166.224:443;
-}
-
-server {
-    listen 443 ssl;
-    server_name *.wikipedia.org;
-    server_name *.m.wikipedia.org;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://wikipedia-text-lb/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name wikimedia.org;
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://wikipedia-text-lb/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-upstream wikipedia-upload-lb {
-    server 208.80.153.240:443;
-    server 208.80.154.240:443;
-    server 91.198.174.208:443;
-    server 103.102.166.240:443;
-}
-
-server {
-    listen 443 ssl;
-    server_name upload.wikimedia.org;
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://wikipedia-upload-lb/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
 server {
     listen 443 ssl;
     server_name *.steamcommunity.com;
     server_name steamcommunity.com;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://23.61.176.149/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
     server_name *.steampowered.com;
     server_name steampowered.com;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://104.112.84.145/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-server {
-    listen 443 ssl;
     server_name *.archiveofourown.org;
     server_name archiveofourown.org;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://104.153.64.122/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-server {
-    listen 443 ssl;
     server_name nyaa.si;
-    server_name www.nyaa.si;
-    server_name sukebei.nyaa.si;
-
-
+    server_name *.nyaa.si;
+    server_name *.wikimedia.org;
+    server_name wikimedia.org;
+    server_name *.wikipedia.org;
+    server_name *.m.wikipedia.org;
+    server_name *.pixivsketch.net;
+    server_name *.pximg.net;
+    server_name *.pixiv.net;
+    
     ssl_certificate ca/pixiv.net.crt;
     ssl_certificate_key ca/pixiv.net.key;
 
     location / {
-        proxy_pass https://185.178.208.182/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-upstream exhentai-lb {
-    server 178.175.128.252:443;
-    server 178.175.128.254:443;
-    server 178.175.129.252:443;
-    server 178.175.129.254:443;
-    server 178.175.132.20:443;
-    server 178.175.132.22:443;
-}
-
-server {
-    listen 443 ssl;
-    server_name exhentai.org;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://exhentai-lb/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-upstream e-hentai-lb {
-    server 104.20.26.25:443;
-    server 104.20.27.25:443;
-}
-
-server {
-    listen 443 ssl;
-    server_name e-hentai.org;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://e-hentai-lb/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name forums.e-hentai.org;
-
-
-    ssl_certificate ca/pixiv.net.crt;
-    ssl_certificate_key ca/pixiv.net.key;
-
-    location / {
-        proxy_pass https://94.100.18.243:443/;
+        # 无污染DNS解析，无需显式指定IP
+        resolver 101.6.6.6:5353 valid=300s;
+        proxy_pass https://$http_host$1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real_IP $remote_addr;

--- a/conf/pixiv.conf
+++ b/conf/pixiv.conf
@@ -13,15 +13,49 @@ server {
 
 server {
     listen 443 ssl;
+    server_name *.steamcommunity.com;
+    server_name steamcommunity.com;
+    server_name *.steampowered.com;
+    server_name steampowered.com;
+    server_name *.archiveofourown.org;
+    server_name archiveofourown.org;
+    server_name nyaa.si;
+    server_name www.nyaa.si;
+    server_name sukebei.nyaa.si;
     server_name forums.e-hentai.org;
-
-    ssl_certificate ca/pixiv.net.crt;
+    server_name upload.wikimedia.org;
+    server_name wikimedia.org;
+    server_name *.wikipedia.org;
+    server_name *.m.wikipedia.org;
+    server_name app-api.pixiv.net;
+    server_name imgaz.pixiv.net;
+    server_name comic.pixiv.net;
+    server_name novel.pixiv.net;
+    server_name source.pixiv.net;
+    server_name i1.pixiv.net;
+    server_name i2.pixiv.net;
+    server_name i3.pixiv.net;
+    server_name i4.pixiv.net;
+    server_name dic.pixiv.net;
+    server_name en-dic.pixiv.net;
+    server_name sensei.pixiv.net;
+    server_name fanbox.pixiv.net;
+    server_name payment.pixiv.net.pixiv.net;
+    server_name factory.pixiv.net;
+    server_name *.pixivsketch.net;
+    server_name *.pximg.net;
+    server_name imp.pixiv.net;
+    server_name mega.nz;
+    server_name g.api.mega.co.nz;
+    server_name *.mega.nz;
+    server_name exhentai.org;
+    server_name *.exhentai.org;
+    ssl_certificate ca/pixiv.net.pem;
     ssl_certificate_key ca/pixiv.net.key;
 
-    client_max_body_size 50M;
-
     location / {
-        proxy_pass https://94.100.18.243:443;
+        resolver 101.6.6.6:5353 valid=300s;
+        proxy_pass https://$http_host$1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real_IP $remote_addr;
@@ -39,16 +73,14 @@ server {
     server_name touch.pixiv.net;
     server_name oauth.secure.pixiv.net;
     server_name www.pixiv.net;
-    server_name app-api.pixiv.net;
 
 
-    ssl_certificate ca/pixiv.net.crt;
+    ssl_certificate ca/pixiv.net.pem;
     ssl_certificate_key ca/pixiv.net.key;
 
     client_max_body_size 50M;
 
     location / {
-        # cloudflare代理需要SNI，IP需要指定为非cloudflare
         proxy_pass https://pixiv;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -94,7 +126,7 @@ server {
     server_name www.google.com;
 
 
-    ssl_certificate ca/pixiv.net.crt;
+    ssl_certificate ca/pixiv.net.pem;
     ssl_certificate_key ca/pixiv.net.key;
 
     location ^~ /recaptcha/ {
@@ -108,38 +140,16 @@ server {
     }
 }
 
+
 server {
     listen 443 ssl;
-    server_name *.steamcommunity.com;
-    server_name steamcommunity.com;
-    server_name *.steampowered.com;
-    server_name steampowered.com;
-    server_name *.archiveofourown.org;
-    server_name archiveofourown.org;
-    server_name nyaa.si;
-    server_name *.nyaa.si;
-    server_name *.wikimedia.org;
-    server_name wikimedia.org;
-    server_name *.wikipedia.org;
-    server_name *.m.wikipedia.org;
-    server_name *.pixivsketch.net;
-    server_name *.pximg.net;
-    server_name *.pixiv.net;
-    server_name exhentai.org;
-    server_name *.exhentai.org;
-    
-    ssl_certificate ca/pixiv.net.crt;
+    server_name i.pximg.net;
+
+
+    ssl_certificate ca/pixiv.net.pem;
     ssl_certificate_key ca/pixiv.net.key;
 
     location / {
-        # 无污染DNS解析，无需显式指定IP
-        resolver 101.6.6.6:5353 valid=300s;
-        proxy_pass https://$http_host$1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real_IP $remote_addr;
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Accept-Encoding '';
-        proxy_buffering off;
+        rewrite ^/(.*)$ https://i.pixiv.cat/$1 redirect;
     }
 }

--- a/conf/pixiv.conf
+++ b/conf/pixiv.conf
@@ -125,6 +125,8 @@ server {
     server_name *.pixivsketch.net;
     server_name *.pximg.net;
     server_name *.pixiv.net;
+    server_name exhentai.org;
+    server_name *.exhentai.org;
     
     ssl_certificate ca/pixiv.net.crt;
     ssl_certificate_key ca/pixiv.net.key;


### PR DESCRIPTION
1. 将显式IP上游更换为无污染dns解析
2. 删除cloudflare cdn的ip（https需要传递sni，无解）

电信网络测试所有域名IP连接正常（不同网络可能会有连接不上的IP），可能只能作为备选的配置文件。